### PR TITLE
Load db credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# NSFS
+
+This project requires database credentials to be provided via environment variables. Create or update the following variables in your environment before running the application:
+
+- `DB_SERVER` – hostname or IP of the database server
+- `DB_SERVER_USERNAME` – username used to connect to the database
+- `DB_SERVER_PASSWORD` – password associated with the database user
+- `DB_DATABASE` – name of the database to use
+
+These values are loaded automatically by `config.php` and used throughout the admin area.

--- a/admin/includes/define.php
+++ b/admin/includes/define.php
@@ -21,23 +21,7 @@ define('USE_PCONNECT', false);
 
 define('SITE_URL', 'https://northsuperfastservice.com/');
 /* DATABASE INFORMATION*/
-//if($_SERVER['HTTP_HOST'] == 'localhost'):
-/***************FOR LOCAL****************/
-define('DB_SERVER','127.0.0.1');
-define('DB_SERVER_USERNAME','u286257250_north');
-define('DB_SERVER_PASSWORD','North@2024');
-define('DB_DATABASE','u286257250_north');
-
-
-/***************FOR LOCAL****************/
-/*else:*/
-/***************FOR SERVER****************/
-/*define('DB_SERVER','localhost');
-define('DB_SERVER_USERNAME','nextscre_kaos');
-define('DB_SERVER_PASSWORD','3Gmfxe79(X6D');
-define('DB_DATABASE','nextscre_kaosforu');*/
-/***************FOR SERVER****************/
-/*endif;*/
+require_once __DIR__ . '/../../config.php';
 
 
 define('STORE_DB_TRANSACTIONS','false');

--- a/config.php
+++ b/config.php
@@ -1,0 +1,12 @@
+<?php
+// Load database configuration from environment variables
+
+foreach (['DB_SERVER', 'DB_SERVER_USERNAME', 'DB_SERVER_PASSWORD', 'DB_DATABASE'] as $var) {
+    $value = getenv($var);
+    if ($value === false) {
+        $value = '';
+    }
+    if (!defined($var)) {
+        define($var, $value);
+    }
+}


### PR DESCRIPTION
## Summary
- add `config.php` to read DB credentials from environment variables
- load `config.php` from `admin/includes/define.php`
- document required environment variables in `README.md`

## Testing
- `php -l config.php` *(fails: command not found)*
- `php -l admin/includes/define.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490d23a9c8832593e3ecba82c7871a